### PR TITLE
Use repo_name instead of project_name as package name

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "{{ cookiecutter.project_name }}",
+  "name": "{{ cookiecutter.repo_name }}",
   "version": "{{ cookiecutter.version }}",
-  "description": "",
+  "description": "{{ cookiecutter.project_name }}",
   "main": "{{ cookiecutter.static_root }}/index.js",
   "scripts": {
     "babel": "./node_modules/.bin/babel-node --presets es2015",


### PR DESCRIPTION
With a `project_name` that has a space, `npm install` fails with npm version 3.9.2 on Mac:

```
npm WARN Invalid name: "My Test Project"
npm WARN my_test_project No description
npm WARN my_test_project No repository field.
npm WARN my_test_project No README data
npm WARN my_test_project No license field.
```

To avoid this, this pull request changes the name used for `package.json` to `repo_name` instead of `project_name`. `project name` is used for the description field instead and `npm test` results are unaffected.
