### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Download `cookiecutter` to a global python path
 In your project directory run
 
     $ cookiecutter git@github.com:hzdg/cookiecutter-webpack.git
+    if you got error when run the command (on windows), try this
+    $ cookiecutter https://github.com/hzdg/cookiecutter-webpack.git
 
 Answer the prompts then `cd` into your newly created project directory.
 


### PR DESCRIPTION
I got an error when running cookiecutter git@github.com:hzdg/cookiecutter-webpack.git.
@goldhand's suggestion to change git@github.com:hzdg/cookiecutter-webpack.git to https://github.com/hzdg/cookiecutter-webpack.git. 

here @goldhand suggestion https://github.com/hzdg/cookiecutter-webpack/issues/15#issuecomment-245483749
